### PR TITLE
Fix missing `BMI_SUCCESS` in get_var_units

### DIFF
--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -603,6 +603,7 @@ contains
        bmi_status = BMI_SUCCESS
     case("pet")
        units = "mm/s"
+       bmi_status = BMI_SUCCESS
     case("qs")
        units = "mm"
        bmi_status = BMI_SUCCESS


### PR DESCRIPTION
This was preventing use in ngen, failing for the `pet` variable--with this fix it seems to run.


## Additions

- Added `BMI_SUCCESS` in the case for `pet` in `sac_var_units`

## Removals

-

## Changes

-

## Testing

1. Ran in ngen with this change--produces output at least.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [X] Linux

